### PR TITLE
Implement Flask dashboard for PPTX analysis

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,139 @@
+import json
+import os
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from flask import Flask, flash, redirect, render_template, request
+from pptx import Presentation
+
+DB_PATH = Path("database.db")
+
+app = Flask(__name__)
+app.secret_key = "secret-key"  # In production, use env variable
+
+
+def init_db():
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS extractions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT,
+                filename TEXT,
+                slide_start INTEGER,
+                slide_end INTEGER,
+                kpi TEXT,
+                table_data TEXT
+            )"""
+        )
+
+
+def insert_record(filename, slide_start, slide_end, kpi, table_data):
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            "INSERT INTO extractions (timestamp, filename, slide_start, slide_end, kpi, table_data) VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                datetime.utcnow().isoformat(sep=" ", timespec="seconds"),
+                filename,
+                slide_start,
+                slide_end,
+                json.dumps(kpi, ensure_ascii=False),
+                json.dumps(table_data, ensure_ascii=False),
+            ),
+        )
+        conn.commit()
+
+
+def get_history():
+    with sqlite3.connect(DB_PATH) as conn:
+        cursor = conn.execute(
+            "SELECT timestamp, filename, slide_start, slide_end, kpi FROM extractions ORDER BY id DESC"
+        )
+        rows = cursor.fetchall()
+    history = [
+        {
+            "timestamp": r[0],
+            "filename": r[1],
+            "slide_start": r[2],
+            "slide_end": r[3],
+            "kpi": json.loads(r[4]),
+        }
+        for r in rows
+    ]
+    return history
+
+
+def parse_slide_text(slide):
+    texts = []
+    for shape in slide.shapes:
+        if hasattr(shape, "text"):
+            text = shape.text.strip()
+            if text:
+                texts.append(text)
+    return texts
+
+
+def parse_table(slide):
+    for shape in slide.shapes:
+        if shape.has_table:
+            table = shape.table
+            headers = [cell.text.strip() for cell in table.rows[0].cells]
+            rows = []
+            for row in table.rows[1:]:
+                rows.append([cell.text.strip() for cell in row.cells])
+            return {"headers": headers, "rows": rows}
+    return {"headers": [], "rows": []}
+
+
+def extract_pptx(path, slide_start, slide_end):
+    prs = Presentation(path)
+    slides = prs.slides
+    if slide_start - 1 >= len(slides) or slide_end - 1 >= len(slides):
+        raise ValueError("Slide range out of bounds")
+    kpi_slide = slides[slide_start - 1]
+    table_slide = slides[slide_end - 1]
+    kpis = parse_slide_text(kpi_slide)
+    table = parse_table(table_slide)
+    return kpis, table
+
+
+@app.route("/", methods=["GET", "POST"])
+def upload():
+    if request.method == "POST":
+        if "pptx" not in request.files:
+            flash("No file part")
+            return redirect(request.url)
+        file = request.files["pptx"]
+        if file.filename == "":
+            flash("No selected file")
+            return redirect(request.url)
+        slide_start = int(request.form.get("start", 31))
+        slide_end = int(request.form.get("end", 32))
+        with NamedTemporaryFile(delete=False, suffix=".pptx") as tmp:
+            file.save(tmp.name)
+            tmp_path = tmp.name
+        try:
+            kpis, table = extract_pptx(tmp_path, slide_start, slide_end)
+            insert_record(file.filename, slide_start, slide_end, kpis, table)
+            slides = (slide_start, slide_end)
+            return render_template(
+                "dashboard.html", kpis=kpis, table=table, slides=slides
+            )
+        except Exception as e:
+            flash(f"Error processing PPTX: {e}")
+            return redirect(request.url)
+        finally:
+            os.unlink(tmp_path)
+    return render_template("upload.html")
+
+
+@app.route("/history")
+def history():
+    history = get_history()
+    return render_template("history.html", history=history)
+
+
+if __name__ == "__main__":
+    init_db()
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+python-pptx

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <title>{% block title %}Dashboard{% endblock %}</title>
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-light bg-light">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="/">PPT Dashboard</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+          <ul class="navbar-nav">
+            <li class="nav-item"><a class="nav-link" href="/">Upload</a></li>
+            <li class="nav-item"><a class="nav-link" href="/history">History</a></li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+    <div class="container mt-4">
+      {% with messages = get_flashed_messages() %}
+        {% if messages %}
+          <div class="alert alert-info">
+            {% for message in messages %}
+              <div>{{ message }}</div>
+            {% endfor %}
+          </div>
+        {% endif %}
+      {% endwith %}
+      {% block content %}{% endblock %}
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  </body>
+</html>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,30 @@
+{% extends 'base.html' %}
+{% block title %}Dashboard{% endblock %}
+{% block content %}
+<h2>Extraction Result</h2>
+<h4>KPIs / Texts (Slide {{ slides[0] }})</h4>
+<ul>
+  {% for item in kpis %}
+    <li>{{ item }}</li>
+  {% endfor %}
+</ul>
+<h4>Table Data (Slide {{ slides[1] }})</h4>
+<table class="table table-bordered table-sm">
+  <thead>
+    <tr>
+      {% for head in table.headers %}
+        <th>{{ head }}</th>
+      {% endfor %}
+    </tr>
+  </thead>
+  <tbody>
+    {% for row in table.rows %}
+    <tr>
+      {% for cell in row %}
+        <td>{{ cell }}</td>
+      {% endfor %}
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/templates/history.html
+++ b/templates/history.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+{% block title %}History{% endblock %}
+{% block content %}
+<h2>Extraction History</h2>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>Date</th>
+      <th>File</th>
+      <th>Slides</th>
+      <th>KPI Summary</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for item in history %}
+    <tr>
+      <td>{{ item['timestamp'] }}</td>
+      <td>{{ item['filename'] }}</td>
+      <td>{{ item['slide_start'] }}-{{ item['slide_end'] }}</td>
+      <td>{{ item['kpi']|truncate(50) }}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% block title %}Upload PPTX{% endblock %}
+{% block content %}
+<h2>Upload PPTX</h2>
+<form method="post" enctype="multipart/form-data">
+  <div class="mb-3">
+    <label for="pptx" class="form-label">PowerPoint file</label>
+    <input type="file" class="form-control" name="pptx" accept=".pptx" required>
+  </div>
+  <div class="mb-3">
+    <label for="start" class="form-label">Slide start</label>
+    <input type="number" class="form-control" name="start" value="31" min="1">
+  </div>
+  <div class="mb-3">
+    <label for="end" class="form-label">Slide end</label>
+    <input type="number" class="form-control" name="end" value="32" min="1">
+  </div>
+  <button type="submit" class="btn btn-primary">Upload</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add simple Flask app with Bootstrap templates
- parse slides via python-pptx and store results in SQLite
- allow upload with configurable slide range
- show parsed data and keep history of extractions
- add requirements file

## Testing
- `black app.py -q`
- `ruff check app.py`

------
https://chatgpt.com/codex/tasks/task_e_687778b0ea5483299a403d446523b01a